### PR TITLE
Replace front page icons with customizer images

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -34,15 +34,15 @@ get_header();
         <div class="container">
             <div class="row text-center gy-4">
                 <div class="col-md-4 icon-item">
-                    <i class="fas fa-dog fa-3x mb-3"></i>
+                    <img src="<?php echo esc_url( get_theme_mod( 'front_icon1_img', get_template_directory_uri() . '/assets/images/puppy_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Puppy icon', 'dreamtails' ); ?>" class="mb-3" />
                     <p class="fw-bold"><?php echo esc_html( get_theme_mod( 'front_icon1_text', __( 'puppies dreaming of you', 'dreamtails' ) ) ); ?></p>
                 </div>
                 <div class="col-md-4 icon-item">
-                    <i class="fas fa-cat fa-3x mb-3"></i>
+                    <img src="<?php echo esc_url( get_theme_mod( 'front_icon2_img', get_template_directory_uri() . '/assets/images/kittens_ico.png' ) ); ?>" alt="<?php esc_attr_e( 'Kitten icon', 'dreamtails' ); ?>" class="mb-3" />
                     <p class="fw-bold"><?php echo esc_html( get_theme_mod( 'front_icon2_text', __( 'kittens dreaming of you', 'dreamtails' ) ) ); ?></p>
                 </div>
                 <div class="col-md-4 icon-item">
-                    <i class="fas fa-concierge-bell fa-3x mb-3"></i>
+                    <img src="<?php echo esc_url( get_theme_mod( 'front_icon3_img', get_template_directory_uri() . '/assets/images/concierge.png' ) ); ?>" alt="<?php esc_attr_e( 'Concierge icon', 'dreamtails' ); ?>" class="mb-3" />
                     <p class="fw-bold"><?php echo esc_html( get_theme_mod( 'front_icon3_text', __( 'concierge service', 'dreamtails' ) ) ); ?></p>
                 </div>
             </div>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -62,6 +62,15 @@ function dreamtails_customize_register( $wp_customize ) {
         'panel' => 'dreamtails_front_page',
     ) );
 
+    $wp_customize->add_setting( 'front_icon1_img', array(
+        'default'           => get_template_directory_uri() . '/assets/images/puppy_ico.png',
+        'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon1_img', array(
+        'label'   => __( 'First Icon Image', 'dreamtails' ),
+        'section' => 'dreamtails_icons',
+    ) ) );
+
     $wp_customize->add_setting( 'front_icon1_text', array(
         'default'           => __( 'puppies dreaming of you', 'dreamtails' ),
         'sanitize_callback' => 'sanitize_text_field',
@@ -72,6 +81,15 @@ function dreamtails_customize_register( $wp_customize ) {
         'type'    => 'text',
     ) );
 
+    $wp_customize->add_setting( 'front_icon2_img', array(
+        'default'           => get_template_directory_uri() . '/assets/images/kittens_ico.png',
+        'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon2_img', array(
+        'label'   => __( 'Second Icon Image', 'dreamtails' ),
+        'section' => 'dreamtails_icons',
+    ) ) );
+
     $wp_customize->add_setting( 'front_icon2_text', array(
         'default'           => __( 'kittens dreaming of you', 'dreamtails' ),
         'sanitize_callback' => 'sanitize_text_field',
@@ -81,6 +99,15 @@ function dreamtails_customize_register( $wp_customize ) {
         'section' => 'dreamtails_icons',
         'type'    => 'text',
     ) );
+
+    $wp_customize->add_setting( 'front_icon3_img', array(
+        'default'           => get_template_directory_uri() . '/assets/images/concierge.png',
+        'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'front_icon3_img', array(
+        'label'   => __( 'Third Icon Image', 'dreamtails' ),
+        'section' => 'dreamtails_icons',
+    ) ) );
 
     $wp_customize->add_setting( 'front_icon3_text', array(
         'default'           => __( 'concierge service', 'dreamtails' ),

--- a/style.css
+++ b/style.css
@@ -345,9 +345,9 @@ a:hover {
     padding-top: 8rem;   /* Increase negative space */
     padding-bottom: 8rem;
 }
-#dreaming-of-you .icon-item i {
-    color: var(--color-primary-dark-grey); /* Dark grey icons */
-    font-size: 5rem; /* Larger icons */
+#dreaming-of-you .icon-item img {
+    width: 5rem;
+    height: auto;
 }
 #dreaming-of-you .icon-item p {
     color: var(--color-text); /* Ensure text color is set */


### PR DESCRIPTION
## Summary
- switch icon markup on the front page from font awesome icons to image tags
- allow selecting icon images via the Customizer
- tweak CSS to style icon images

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68472d17f9ac8326875849db02841a6d