### PR TITLE
Add Featured Pets images to customizer

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -59,14 +59,14 @@ get_header();
                 <div class="col-12 col-md-9">
                     <div class="featured-pets-images d-flex flex-wrap flex-md-nowrap justify-content-between">
                         <?php
-                        // --- Placeholder Content ---
-                        // Replace with WP_Query for 'pet' CPT
-                        for ($i = 1; $i <= 3; $i++) { ?>
+                        // Output featured pet images from Customizer settings.
+                        for ( $i = 1; $i <= 3; $i++ ) {
+                            $image = get_theme_mod( 'front_featured_pet_image' . $i, get_template_directory_uri() . '/assets/images/pet-placeholder-' . $i . '.jpg' );
+                            ?>
                             <div class="featured-pet-image mb-3 mb-md-0 text-center">
-                                <img src="<?php echo esc_url( get_template_directory_uri() . '/assets/images/pet-placeholder-' . $i . '.jpg'); ?>" alt="Featured Pet <?php echo $i; ?>" class="img-fluid">
+                                <img src="<?php echo esc_url( $image ); ?>" alt="<?php echo esc_attr( sprintf( __( 'Featured Pet %d', 'dreamtails' ), $i ) ); ?>" class="img-fluid">
                             </div>
                         <?php }
-                        // --- End Placeholder ---
                         ?>
                     </div>
                 </div>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -135,6 +135,18 @@ function dreamtails_customize_register( $wp_customize ) {
         'type'    => 'text',
     ) );
 
+    // Featured Pet Images
+    for ( $i = 1; $i <= 3; $i++ ) {
+        $wp_customize->add_setting( "front_featured_pet_image{$i}", array(
+            'default'           => get_template_directory_uri() . "/assets/images/pet-placeholder-{$i}.jpg",
+            'sanitize_callback' => 'esc_url_raw',
+        ) );
+        $wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, "front_featured_pet_image{$i}", array(
+            'label'   => sprintf( __( 'Featured Pet Image %d', 'dreamtails' ), $i ),
+            'section' => 'dreamtails_featured_pets',
+        ) ) );
+    }
+
     /* Testimonials */
     $wp_customize->add_section( 'dreamtails_testimonials', array(
         'title' => __( 'Testimonials', 'dreamtails' ),


### PR DESCRIPTION
## Summary
- include 3 Featured Pets images in the customizer
- render these images on the front page using customizer settings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68473040a5e08326b68d66d4f68c3199