### PR TITLE
Update fonts to Mollie Glaston

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -165,7 +165,8 @@ function dreamtails_scripts() {
     wp_enqueue_style( 'dreamtails-style', get_stylesheet_uri(), array('bootstrap'), DREAMTAILS_VERSION );
 
     // Google Fonts (Example - keep if needed)
-    wp_enqueue_style( 'dreamtails-josefin-sans', 'https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&display=swap', array(), null );
+//     wp_enqueue_style( 'dreamtails-josefin-sans', 'https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;700&display=swap', array(), null );
+    // Local Mollie Glaston font loaded via style.css
     // wp_enqueue_style( 'dreamtails-google-fonts', 'https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@700&display=swap', array(), null );
 
     // Enqueue comment reply script (Essential for threaded comments)

--- a/style.css
+++ b/style.css
@@ -11,6 +11,15 @@ Tags: custom-background, custom-logo, custom-menu, featured-images, theme-option
 Text Domain: dreamtails
 */
 
+@font-face {
+    font-family: "Mollie Glaston";
+    src: url("assets/fonts/mollie_glaston.otf") format("opentype"),
+         url("assets/fonts/mollie_glaston.ttf") format("truetype");
+    font-weight: normal;
+    font-style: normal;
+    font-display: swap;
+}
+
 /* --- Variables --- */
 :root {
     --color-primary-light-blue-grey: #BCC9C5; /* Primary 1 - Header/Footer BG */
@@ -76,7 +85,7 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     margin-top: 0;
 }
 h1, h2 {
-    font-family: "Josefin Sans", sans-serif;
+    font-family: "Mollie Glaston", sans-serif;
 }
 
 /* Link styling */
@@ -350,7 +359,7 @@ a:hover {
 }
 #dreaming-of-you .icon-item p {
     color: var(--color-text); /* Ensure text color is set */
-    font-family: 'Josefin Sans', sans-serif; /* Google font */
+    font-family: 'Mollie Glaston', sans-serif; /* Google font */
 }
 
 /* Featured Pets Section */


### PR DESCRIPTION
## Summary
- load `Mollie Glaston` font from local assets with `@font-face`
- use new font for `h1`/`h2` headings and icon section
- stop loading Josefin Sans from Google

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684740764938832691db8a5696954a00