### PR TITLE
Update footer navigation and styling

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,13 +6,20 @@
  */
 ?>
 
-</div><footer id="colophon" class="site-footer text-white pt-5 pb-4" style="background-color: var(--color-footer-bg); color: var(--color-primary-dark-teal);"> <?php // Using custom color var ?>
+</div><footer id="colophon" class="site-footer pt-5 pb-4" style="background-color: var(--color-footer-bg); color: #000;"> <?php // Using custom color var ?>
     <div class="container">
         <div class="row gy-4"> <?php // Bootstrap row with gutter spacing ?>
 
             <?php // Footer Column 1: Navigation ?>
             <div class="col-lg-3 col-md-6 footer-navigation">
-                <?php if ( has_nav_menu( 'footer' ) ) :
+                <?php if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) : ?>
+                    <div class="footer-logo mb-3">
+                        <?php the_custom_logo(); ?>
+                    </div>
+                <?php endif; ?>
+                <h5 class="widget-title">Navigation</h5>
+                <?php
+                if ( has_nav_menu( 'footer' ) ) {
                     wp_nav_menu(
                         array(
                             'theme_location' => 'footer',
@@ -21,17 +28,8 @@
                             'depth'          => 1,
                         )
                     );
-                else : ?>
-                    <h5 class="widget-title"><?php esc_html_e('Quick Links', 'dreamtails'); ?></h5>
-                    <ul class="list-unstyled footer-menu">
-                        <li><a href="#">View Dream Pets</a></li>
-                        <li><a href="#">About Dream Tails</a></li>
-                        <li><a href="#">Financing</a></li>
-                        <li><a href="#">Puppy Breeds</a></li>
-                        <li><a href="#">Contact Us</a></li>
-                        <li><a href="#">Account</a></li>
-                    </ul>
-                <?php endif; ?>
+                }
+                ?>
                 <?php if ( is_active_sidebar( 'footer-1' ) ) : ?>
                     <?php dynamic_sidebar( 'footer-1' ); ?>
                 <?php endif; ?>
@@ -63,8 +61,8 @@
                     <p><?php esc_html_e( 'Part of the Petland family of stores.', 'dreamtails' ); ?></p>
                     <?php // Add social icons here if desired ?>
                     <div>
-                        <a href="#" class="text-white me-2"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#" class="text-white me-2"><i class="fab fa-instagram"></i></a>
+                        <a href="#" class="me-2"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#" class="me-2"><i class="fab fa-instagram"></i></a>
                         <?php // Add links ?>
                     </div>
                 <?php endif; ?>
@@ -72,7 +70,7 @@
 
         <div class="footer-bottom text-center">
             <p class="mb-1">&copy; <?php echo esc_html( date_i18n( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All Rights Reserved.', 'dreamtails' ); ?></p>
-            <p class="mb-0 small"><?php esc_html_e( 'Developed by', 'dreamtails' ); ?> <a href="https://cosmickmedia.com/" target="_blank" rel="noopener" class="text-white">Cosmick Media</a></p>
+            <p class="mb-0 small"><?php esc_html_e( 'Developed by', 'dreamtails' ); ?> <a href="https://cosmickmedia.com/" target="_blank" rel="noopener">Cosmick Media</a></p>
         </div></div></footer></div><?php wp_footer(); ?>
 
 </body>

--- a/style.css
+++ b/style.css
@@ -234,19 +234,19 @@ a:hover {
 /* --- Footer --- */
 .site-footer {
     background-color: var(--color-footer-bg);
-    color: var(--color-primary-dark-teal); /* Base text color for footer */
+    color: #000; /* Base text color for footer */
     font-size: 0.95rem; /* Slightly larger footer text */
     padding-top: 3rem; /* Use Bootstrap pt-5 class on element instead? */
     padding-bottom: 2rem; /* Use Bootstrap pb-4 class on element instead? */
 }
 
 .site-footer a {
-    color: var(--color-primary-dark-teal);
-    text-decoration: underline; /* Underline footer links */
+    color: #000;
+    text-decoration: none;
     transition: color 0.3s ease;
 }
 .site-footer a:hover {
-    color: #fff; /* White on hover for contrast */
+    color: #000;
     text-decoration: none;
 }
 
@@ -263,9 +263,16 @@ a:hover {
 .footer-menu {
     list-style: none;
     padding-left: 0; /* Remove default ul padding */
+    font-family: "Mollie Glaston", sans-serif;
 }
 .footer-menu li {
     margin-bottom: 0.5rem;
+}
+
+/* Footer logo size */
+.footer-logo img {
+    width: 200px;
+    height: auto;
 }
 
 /* Align icons in footer info sections */
@@ -286,11 +293,11 @@ a:hover {
     margin-bottom: 0.25rem;
 }
 .footer-bottom a { /* Ensure copyright link inherits footer link style */
-    color: var(--color-primary-dark-teal);
-    text-decoration: underline;
+    color: #000;
+    text-decoration: none;
 }
 .footer-bottom a:hover {
-    color: #fff;
+    color: #000;
     text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- render footer menu and logo in first column
- remove fallback quick links widget
- set footer colors to black and remove link underlines
- use Mollie font for footer navigation
- style footer logo size

## Testing
- `php -l footer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684745c2452083268b330accbf9e3e08