### PR TITLE
Add global phone setting and header enhancements

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -39,10 +39,12 @@
                 <h5 class="widget-title"><?php echo esc_html( get_theme_mod( 'footer_col2_heading', __( 'Dream Tails Sarasota', 'dreamtails' ) ) ); ?></h5>
                 <?php
                 $address = get_theme_mod( 'footer_col2_address', "6453 Lockwood Ridge Rd\nSarasota, FL 34243" );
-                $phone   = get_theme_mod( 'footer_col2_phone', '941-203-1196' );
+                $phone   = get_theme_mod( 'homepage_phone_number', '' );
                 ?>
                 <p><i class="fas fa-map-marker-alt me-2"></i><?php echo nl2br( esc_html( $address ) ); ?></p>
-                <p><i class="fas fa-phone me-2"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a></p>
+                <?php if ( $phone ) : ?>
+                    <p><i class="fas fa-phone me-2"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a></p>
+                <?php endif; ?>
                 <div class="mt-2">
                     <iframe src="https://www.google.com/maps?q=<?php echo rawurlencode( $address ); ?>&amp;output=embed" width="100%" height="150" style="border:0;" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                 </div>

--- a/front-page.php
+++ b/front-page.php
@@ -20,9 +20,12 @@ get_header();
                         <h1 class="display-4" style="color: var(--color-primary-dark-teal);">
                             <?php echo esc_html( get_theme_mod( 'front_hero_heading', __( 'where pets find their people', 'dreamtails' ) ) ); ?>
                         </h1>
-                        <a href="<?php echo esc_url( get_theme_mod( 'front_hero_button_url', '/book-appointment/' ) ); ?>" class="btn btn-lg mt-3" style="background-color: var(--color-button); color: var(--color-button-text);">
-                            <i class="fa-regular fa-calendar-check me-2"></i> <?php echo esc_html( get_theme_mod( 'front_hero_button_text', __( 'Book an Appointment', 'dreamtails' ) ) ); ?>
-                        </a>
+                        <?php $hero_url = get_theme_mod( 'front_hero_button_url', '' ); ?>
+                        <?php if ( $hero_url ) : ?>
+                            <a href="<?php echo esc_url( $hero_url ); ?>" class="btn btn-lg mt-3" style="background-color: var(--color-button); color: var(--color-button-text);">
+                                <i class="fa-regular fa-calendar-check me-2"></i> <?php echo esc_html( get_theme_mod( 'front_hero_button_text', __( 'Book an Appointment', 'dreamtails' ) ) ); ?>
+                            </a>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>

--- a/header.php
+++ b/header.php
@@ -47,15 +47,31 @@
                     </div>
                 </div>
 
-                <?php // Header "Book Appointment" Button (Top Right) - Larger, New BG, Rounded ?>
+                <?php // Header contact info and CTA button ?>
                 <div class="header-top-button d-flex align-items-center">
-                    <span class="header-phone-number me-3">
-                        <i class="fas fa-phone me-2"></i>987-654-3210
-                    </span>
-                    <a href="/book-appointment/" class="btn btn-lg btn-book-appointment"> <?php // Use btn-lg and custom class ?>
-                        <i class="fa-regular fa-calendar-check me-2"></i><?php esc_html_e('Book Appointment', 'dreamtails'); ?>
-                    </a>
-                    <?php // TODO: Update href ?>
+                    <div class="header-contact d-flex align-items-center me-3">
+                        <?php
+                        $phone     = get_theme_mod( 'homepage_phone_number', '' );
+                        $book_url  = get_theme_mod( 'header_book_button_url', '' );
+                        if ( $phone ) : ?>
+                            <span class="header-phone-number me-3">
+                                <i class="fas fa-phone me-2"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a>
+                            </span>
+                        <?php endif; ?>
+                        <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3">
+                            <i class="fas fa-user"></i>
+                        </a>
+                        <?php if ( function_exists( 'wc_get_cart_url' ) && ! is_catalog_mode() ) : ?>
+                            <a href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="header-icon header-cart-icon me-3">
+                                <i class="fas fa-shopping-cart"></i>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                    <?php if ( $book_url ) : ?>
+                        <a href="<?php echo esc_url( $book_url ); ?>" class="btn btn-lg btn-book-appointment">
+                            <i class="fa-regular fa-calendar-check me-2"></i><?php esc_html_e( 'Book Appointment', 'dreamtails' ); ?>
+                        </a>
+                    <?php endif; ?>
                 </div>
 
             </div></div><?php // --- Main Navigation Bar (Bottom Bar - White BG, Hamburger ALWAYS Left, Menu Center) --- ?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -75,6 +75,32 @@ function dreamtails_customize_register( $wp_customize ) {
         'section' => 'dreamtails_hero',
     ) ) );
 
+    /* Homepage Settings */
+    $wp_customize->add_section( 'dreamtails_homepage_settings', array(
+        'title' => __( 'Homepage Settings', 'dreamtails' ),
+        'panel' => 'dreamtails_front_page',
+    ) );
+
+    $wp_customize->add_setting( 'homepage_phone_number', array(
+        'default'           => '941-203-1196',
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'homepage_phone_number', array(
+        'label'   => __( 'Phone Number', 'dreamtails' ),
+        'section' => 'dreamtails_homepage_settings',
+        'type'    => 'text',
+    ) );
+
+    $wp_customize->add_setting( 'header_book_button_url', array(
+        'default'           => '',
+        'sanitize_callback' => 'esc_url_raw',
+    ) );
+    $wp_customize->add_control( 'header_book_button_url', array(
+        'label'   => __( 'Header Book Appointment URL', 'dreamtails' ),
+        'section' => 'dreamtails_homepage_settings',
+        'type'    => 'url',
+    ) );
+
     /* Icon Section */
     $wp_customize->add_section( 'dreamtails_icons', array(
         'title' => __( 'Icon Section', 'dreamtails' ),

--- a/style.css
+++ b/style.css
@@ -158,6 +158,26 @@ a:hover {
     white-space: nowrap;
 }
 
+.header-icon {
+    color: var(--color-primary-dark-teal);
+    text-decoration: none;
+    font-size: 1.2rem;
+}
+.header-icon + .header-icon {
+    margin-left: 0.5rem;
+}
+
+@media (max-width: 767.98px) {
+    .header-top-button {
+        flex-direction: column;
+        text-align: center;
+    }
+    .header-contact {
+        margin-bottom: 0.5rem;
+        justify-content: center;
+    }
+}
+
 
 /* Main Navigation Bar Styles */
 .main-navbar {


### PR DESCRIPTION
## Summary
- allow phone and header booking URL to be configured in the customizer
- show phone, My Account and optionally Cart icons in the header
- pull phone setting into the footer
- hide Book Appointment buttons if URL not set
- stack phone and button on small screens

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474e5ff1f883268a6e33e7ed5365c0