### PR TITLE
Enhance header settings

### DIFF
--- a/header.php
+++ b/header.php
@@ -48,11 +48,13 @@
                 </div>
 
                 <?php // Header contact info and CTA button ?>
-                <div class="header-top-button d-flex align-items-center">
-                    <div class="header-contact d-flex align-items-center me-3">
+                <div class="header-top-button">
+                    <div class="header-contact d-flex align-items-center">
                         <?php
-                        $phone     = get_theme_mod( 'homepage_phone_number', '' );
-                        $book_url  = get_theme_mod( 'header_book_button_url', '' );
+                        $phone      = get_theme_mod( 'homepage_phone_number', '' );
+                        $book_url   = get_theme_mod( 'header_book_button_url', '' );
+                        $book_text  = get_theme_mod( 'header_book_button_text', __( 'Book Appointment', 'dreamtails' ) );
+                        $book_icon  = get_theme_mod( 'header_book_button_icon', 'fa-regular fa-calendar-check' );
                         if ( $phone ) : ?>
                             <span class="header-phone-number me-3">
                                 <i class="fas fa-phone me-2"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a>
@@ -68,8 +70,8 @@
                         <?php endif; ?>
                     </div>
                     <?php if ( $book_url ) : ?>
-                        <a href="<?php echo esc_url( $book_url ); ?>" class="btn btn-lg btn-book-appointment">
-                            <i class="fa-regular fa-calendar-check me-2"></i><?php esc_html_e( 'Book Appointment', 'dreamtails' ); ?>
+                        <a href="<?php echo esc_url( $book_url ); ?>" class="btn btn-lg btn-book-appointment d-inline-flex align-items-center mt-2">
+                            <?php if ( $book_icon ) : ?><i class="<?php echo esc_attr( $book_icon ); ?> me-2"></i><?php endif; ?><?php echo esc_html( $book_text ); ?>
                         </a>
                     <?php endif; ?>
                 </div>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -101,6 +101,27 @@ function dreamtails_customize_register( $wp_customize ) {
         'type'    => 'url',
     ) );
 
+    $wp_customize->add_setting( 'header_book_button_text', array(
+        'default'           => __( 'Book Appointment', 'dreamtails' ),
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'header_book_button_text', array(
+        'label'   => __( 'Header Book Appointment Text', 'dreamtails' ),
+        'section' => 'dreamtails_homepage_settings',
+        'type'    => 'text',
+    ) );
+
+    $wp_customize->add_setting( 'header_book_button_icon', array(
+        'default'           => 'fa-regular fa-calendar-check',
+        'sanitize_callback' => 'sanitize_text_field',
+    ) );
+    $wp_customize->add_control( 'header_book_button_icon', array(
+        'label'       => __( 'Header Book Appointment Icon', 'dreamtails' ),
+        'section'     => 'dreamtails_homepage_settings',
+        'type'        => 'text',
+        'description' => __( 'Font Awesome class, e.g. fa-calendar-check', 'dreamtails' ),
+    ) );
+
     /* Icon Section */
     $wp_customize->add_section( 'dreamtails_icons', array(
         'title' => __( 'Icon Section', 'dreamtails' ),

--- a/style.css
+++ b/style.css
@@ -167,13 +167,25 @@ a:hover {
     margin-left: 0.5rem;
 }
 
+.header-top-button {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
+}
+
+.header-contact {
+    margin-bottom: 0.5rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
 @media (max-width: 767.98px) {
     .header-top-button {
-        flex-direction: column;
+        align-items: center;
         text-align: center;
     }
     .header-contact {
-        margin-bottom: 0.5rem;
         justify-content: center;
     }
 }


### PR DESCRIPTION
## Summary
- add header customizer options for button text and icon
- reorganize header layout so contact icons sit above the button
- use new settings in the header
- adjust styling for new layout

## Testing
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684751a831888326b0c600f3be1ed557