### PR TITLE
Adjust header styles and mobile hero

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -14,7 +14,7 @@ get_header();
     <section class="front-page-hero">
         <div class="container">
             <div class="row align-items-center">
-                <div class="col-md-6 d-none d-md-block p-0 hero-image" style="background-image: url('<?php echo esc_url( get_theme_mod( 'front_hero_image', get_template_directory_uri() . '/assets/images/homepage_hero.png' ) ); ?>');"></div>
+                <div class="col-12 col-md-6 p-0 hero-image mb-4 mb-md-0" style="background-image: url('<?php echo esc_url( get_theme_mod( 'front_hero_image', get_template_directory_uri() . '/assets/images/homepage_hero.png' ) ); ?>');"></div>
                 <div class="col-md-6">
                     <div class="hero-content bg-light bg-opacity-75 p-4 p-md-5 rounded text-center">
                         <h1 class="display-4" style="color: var(--color-primary-dark-teal);">

--- a/header.php
+++ b/header.php
@@ -57,7 +57,7 @@
                         $book_icon  = get_theme_mod( 'header_book_button_icon', 'fa-regular fa-calendar-check' );
                         if ( $phone ) : ?>
                             <span class="header-phone-number me-3">
-                                <i class="fas fa-phone me-2"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a>
+                                <i class="fas fa-phone me-2 header-icon"></i><a href="tel:<?php echo esc_attr( preg_replace( '/[^0-9+]/', '', $phone ) ); ?>"><?php echo esc_html( $phone ); ?></a>
                             </span>
                         <?php endif; ?>
                         <a href="<?php echo esc_url( function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : '#' ); ?>" class="header-icon header-account-icon me-3">

--- a/style.css
+++ b/style.css
@@ -153,14 +153,21 @@ a:hover {
 
 /* Phone number displayed in the top header bar */
 .header-phone-number {
-    color: var(--color-primary-dark-teal);
+    color: #000;
     font-weight: bold;
     white-space: nowrap;
+    font-size: 1.25rem;
+}
+.header-phone-number i {
+    font-size: 1.2rem;
 }
 
 .header-icon {
     color: var(--color-primary-dark-teal);
     text-decoration: none;
+    font-size: 1.2rem;
+}
+.header-icon i {
     font-size: 1.2rem;
 }
 .header-icon + .header-icon {
@@ -181,12 +188,15 @@ a:hover {
 }
 
 @media (max-width: 767.98px) {
+    .header-phone-number a {
+        display: none;
+    }
     .header-top-button {
-        align-items: center;
-        text-align: center;
+        align-items: flex-end;
+        text-align: right;
     }
     .header-contact {
-        justify-content: center;
+        justify-content: flex-end;
     }
 }
 
@@ -364,7 +374,7 @@ a:hover {
         overflow: visible;
     }
     .hero-image {
-        display: none;
+        display: block;
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak phone icon layout in the header
- restyle header phone number and icons
- ensure phone number hides on mobile and keep book button right aligned
- display hero image on mobile

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847597a739483268c4f4b225609590e